### PR TITLE
Update Revocation to Remove EAKs

### DIFF
--- a/examples/simple.php
+++ b/examples/simple.php
@@ -91,9 +91,11 @@ foreach ($queryResult as $record) {
 $isaac_client_id = 'db1744b9-3fb6-4458-a291-0bc677dba08b';
 $client->share('test-contact', $isaac_client_id);
 
-// Share all of the records of type 'test-contact' with Isaac's email address.
-// This only works if the client has opted into discovery of their client_id.
-$client->share('test-contact', 'ijones+feedback@tozny.com');
+// Alternatively, share all of the records of type 'test-contact' with Isaac's
+// email address. This only works if the client has opted into discovery of
+// their client_id.
+
+//$client->share('test-contact', 'ijones+feedback@tozny.com');
 
 /**
  * ---------------------------------------------------------
@@ -198,7 +200,7 @@ $client->revoke('test-contact', 'ijones+feedback@tozny.com');
 // Delete the record we created above
 $client->delete($record_id);
 
-# Delete all of the records of type test-contact from previous runs:
+// Delete all of the records of type test-contact from previous runs:
 $data = false;
 $raw = false;
 $writer = null;

--- a/php/Client.php
+++ b/php/Client.php
@@ -338,6 +338,9 @@ class Client
         $deny->deny = [['read' => new \stdClass()]];
 
         $this->conn->put($path, $deny);
+
+        // Delete any existing access key
+        $this->conn->delete_access_key($id, $id, $reader_id, $type);
     }
 
     /**

--- a/php/Connection/Connection.php
+++ b/php/Connection/Connection.php
@@ -80,6 +80,16 @@ abstract class Connection
     abstract function put_access_key(string $writer_id, string $user_id, string $reader_id, string $type, string $ak);
 
     /**
+     * Delete an access key on the server.
+     *
+     * @param string $writer_id Writer/Authorizer for the access key
+     * @param string $user_id   Record subject
+     * @param string $reader_id Authorized reader
+     * @param string $type      Record type for which the key will be used
+     */
+    abstract function delete_access_key(string $writer_id, string $user_id, string $reader_id, string $type);
+
+    /**
      * Attempt to find a client based on their email address.
      *
      * @param string $email

--- a/php/Connection/GuzzleConnection.php
+++ b/php/Connection/GuzzleConnection.php
@@ -132,6 +132,24 @@ class GuzzleConnection extends Connection
     }
 
     /**
+     * Delete an access key on the server.
+     *
+     * @param string $writer_id Writer/Authorizer for the access key
+     * @param string $user_id   Record subject
+     * @param string $reader_id Authorized reader
+     * @param string $type      Record type for which the key will be used
+     */
+    function delete_access_key(string $writer_id, string $user_id, string $reader_id, string $type)
+    {
+        $path = $this->uri('v1', 'storage', 'access_keys', $writer_id, $user_id, $reader_id, $type);
+        $this->client->request('DELETE', $path);
+
+        // Remove any cached keys
+        $cache_key = "{$writer_id}.{$user_id}.{$type}";
+        unset($this->ak_cache[ $cache_key ]);
+    }
+
+    /**
      * Attempt to find a client based on their email address.
      *
      * @param string $email

--- a/test/phpunit/Connection/ConnectionTest.php
+++ b/test/phpunit/Connection/ConnectionTest.php
@@ -91,6 +91,11 @@ class ConcreteConnection extends Connection
         // TODO: Implement put_access_key() method.
     }
 
+    function delete_access_key(string $writer_id, string $user_id, string $reader_id, string $type)
+    {
+        // TODO: Implement delete_access_key() method.
+    }
+
     function find_client(string $email): Response
     {
         // TODO: Implement find_client() method.


### PR DESCRIPTION
When a record type is unshared, we should automatically delete the EAK for the reader.

Also, update the example code to only share with Isaac _once_ otherwise the example code will fail.

Fixes E3DB-648