### PR TITLE
Add backup routines for client creation

### DIFF
--- a/examples/registration.php
+++ b/examples/registration.php
@@ -60,6 +60,8 @@ $client_info = Client::register($token, $client_name, $wrapped_key);
 // passing your private key and a backup flag when registering. The private key is
 // not sent anywhere, but is used by the newly-created client to sign an encrypted
 // copy of its credentials that is itself stored in e3db for later use.
+//
+// Client credentials are not backed up by default.
 
 // $client_info = Client::register($token, $client_name, $wrapped_key, $private_key, true);
 

--- a/examples/registration.php
+++ b/examples/registration.php
@@ -55,6 +55,14 @@ echo 'Client Name: ' . $client_name . "\n";
 // a new client with the system. Remember to keep your private key private!
 $client_info = Client::register($token, $client_name, $wrapped_key);
 
+// Optionally, you can automatically back up the credentials of the newly-created
+// client to your InnoVault account (accessible via https://console.tozny.com) by
+// passing your private key and a backup flag when registering. The private key is
+// not sent anywhere, but is used by the newly-created client to sign an encrypted
+// copy of its credentials that is itself stored in e3db for later use.
+
+// $client_info = Client::register($token, $client_name, $wrapped_key, $private_key, true);
+
 echo 'Client ID:   ' . $client_info->client_id . "\n";
 echo 'API Key ID:  ' . $client_info->api_key_id . "\n";
 echo 'API Secret:  ' . $client_info->api_secret . "\n";

--- a/php/Client.php
+++ b/php/Client.php
@@ -402,6 +402,10 @@ class Client
         $client_info = ClientDetails::decode((string) $resp->getBody());
 
         if ($backup && $backup_client_id) {
+            if (empty($private_key)) {
+                throw new \RuntimeException('Cannot back up credentials without a private key!');
+            }
+
             $config = new Config(
                 $client_info->client_id,
                 $client_info->api_key_id,

--- a/php/Client.php
+++ b/php/Client.php
@@ -34,6 +34,7 @@ namespace Tozny\E3DB;
 
 use GuzzleHttp\Exception\RequestException;
 use Tozny\E3DB\Connection\Connection;
+use Tozny\E3DB\Connection\GuzzleConnection;
 use function Tozny\E3DB\Crypto\base64decode;
 use function Tozny\E3DB\Crypto\base64encode;
 use function Tozny\E3DB\Crypto\random_key;
@@ -258,6 +259,33 @@ class Client
     }
 
     /**
+     * Back up the client's configuration to E3DB in a serialized format that can be read
+     * by the Admin Console. The stored configuration will be shared with the specified client,
+     * and the account service notified that the sharing has taken place.
+     *
+     * @param string $client_id          Unique ID of the client to which we're backing up
+     * @param string $registration_token Original registration token used to create the client
+     */
+    public function backup($client_id, $registration_token)
+    {
+        $credentials = [
+            'version'      => '1',
+            'client_id'    => \json_encode($this->config->client_id),
+            'api_key_id'   => \json_encode($this->config->api_key_id),
+            'api_secret'   => \json_encode($this->config->api_secret),
+            'client_email' => '""',
+            'public_key'   => \json_encode($this->config->public_key),
+            'private_key'  => \json_encode($this->config->private_key),
+            'api_url'      => \json_encode($this->config->api_url),
+        ];
+        $this->write('tozny.key_backup', $credentials, ['client' => $this->config->client_id]);
+        $this->share('tozny.key_backup', $client_id);
+
+        $url = $this->conn->uri('v1', 'account', 'backup', $registration_token, $this->config->client_id);
+        $this->conn->post($url, null);
+    }
+
+    /**
      * Query E3DB records according to a set of selection criteria.
      *
      * The default behavior is to return all records written by the
@@ -350,11 +378,13 @@ class Client
      * @param string    $registration_token Registration token as presented by the admin console
      * @param string    $client_name        Distinguishable name to be used for the token in the console
      * @param PublicKey $public_key         Curve25519 public key component used for encryption
+     * @param string    [$private_key]      Optional Curve25519 private key component used to sign the backup key
+     * @param bool      [$backup]           Optional flag to automatically back up the newly-created credentials to the account service
      * @param string    [$api_url]          Base URI for the e3DB API
      *
      * @return ClientDetails
      */
-    public static function register(string $registration_token, string $client_name, PublicKey $public_key, string $api_url = 'https://api.e3db.com'): ClientDetails
+    public static function register(string $registration_token, string $client_name, PublicKey $public_key, string $private_key = '', $backup = false, string $api_url = 'https://api.e3db.com'): ClientDetails
     {
         $path = $api_url . '/v1/account/e3db/clients/register';
         $payload = ['token' => $registration_token, 'client' => ['name' => $client_name, 'public_key' => $public_key]];
@@ -362,11 +392,31 @@ class Client
         try {
             $client = new \GuzzleHttp\Client(['base_uri' => $api_url]);
             $resp = $client->request('POST', $path, ['json' => $payload]);
+            $backup_client_id = count($resp->getHeader('X-Backup-Client')) > 0 ?
+                $resp->getHeader('X-Backup-Client')[0] :
+                false;
         } catch (RequestException $re) {
             throw new \RuntimeException('Error while registering a new client!');
         }
 
-        return ClientDetails::decode((string) $resp->getBody());
+        $client_info = ClientDetails::decode((string) $resp->getBody());
+
+        if ($backup && $backup_client_id) {
+            $config = new Config(
+                $client_info->client_id,
+                $client_info->api_key_id,
+                $client_info->api_secret,
+                $public_key->curve25519,
+                $private_key
+            );
+
+            $connection = new GuzzleConnection($config);
+            $client = new Client($config, $connection);
+
+            $client->backup($backup_client_id, $registration_token);
+        }
+
+        return $client_info;
     }
 
     /**

--- a/php/Client.php
+++ b/php/Client.php
@@ -407,7 +407,8 @@ class Client
                 $client_info->api_key_id,
                 $client_info->api_secret,
                 $public_key->curve25519,
-                $private_key
+                $private_key,
+                $api_url
             );
 
             $connection = new GuzzleConnection($config);

--- a/test/phpunit/ClientTest.php
+++ b/test/phpunit/ClientTest.php
@@ -54,8 +54,8 @@ class ClientTest extends TestCase
         $client2_public_key = new PublicKey($client2_public_key);
         $client2_name = uniqid('share_client_');
 
-        $client1 = Client::register($token, $client1_name, $client1_public_key, \getenv('API_URL'));
-        $client2 = Client::register($token, $client2_name, $client2_public_key, \getenv('API_URL'));
+        $client1 = Client::register($token, $client1_name, $client1_public_key, '', false, \getenv('API_URL'));
+        $client2 = Client::register($token, $client2_name, $client2_public_key, '', false, \getenv('API_URL'));
         self::$client_2_id = $client2->client_id;
 
         self::$config = new Config(
@@ -85,7 +85,7 @@ class ClientTest extends TestCase
         $public_key = new PublicKey($public_key);
         $name = uniqid('test_client_');
 
-        $client = Client::register($token, $name, $public_key, \getenv('API_URL'));
+        $client = Client::register($token, $name, $public_key, '', false, \getenv('API_URL'));
 
         $this->assertEquals($name, $client->name);
         $this->assertEquals($public_key->curve25519, $client->public_key->curve25519);

--- a/test/phpunit/ClientTest.php
+++ b/test/phpunit/ClientTest.php
@@ -29,6 +29,11 @@ class ClientTest extends TestCase
     private static $client;
 
     /**
+     * @var Client
+     */
+    private static $client2;
+
+    /**
      * @var string
      */
     private static $client_2_id;
@@ -50,7 +55,7 @@ class ClientTest extends TestCase
         list($client1_public_key, $client1_private_key) = Client::generate_keypair();
         $client1_public_key = new PublicKey($client1_public_key);
         $client1_name = uniqid('test_client_');
-        list($client2_public_key, ) = Client::generate_keypair();
+        list($client2_public_key, $client2_private_key) = Client::generate_keypair();
         $client2_public_key = new PublicKey($client2_public_key);
         $client2_name = uniqid('share_client_');
 
@@ -70,6 +75,19 @@ class ClientTest extends TestCase
         self::$conn = new GuzzleConnection(self::$config);
 
         self::$client = new Client(self::$config, self::$conn);
+
+        $config2 = new Config(
+            $client2->client_id,
+            $client2->api_key_id,
+            $client2->api_secret,
+            $client2->public_key->curve25519,
+            $client2_private_key,
+            \getenv('API_URL')
+        );
+
+        $conn2 = new GuzzleConnection($config2);
+
+        self::$client2 = new Client($config2, $conn2);
 
         // Write a record
         self::$type = uniqid('type_');
@@ -223,7 +241,7 @@ class ClientTest extends TestCase
 
     public function test_write()
     {
-         $data = [
+        $data = [
             'first' => 'this is a string',
             'second' => 'test',
         ];
@@ -284,9 +302,21 @@ class ClientTest extends TestCase
 
     public function test_share()
     {
-        self::$client->share(self::$type, self::$client_2_id);
+        $data = [
+            'first' => 'this is a string',
+            'second' => 'test',
+        ];
+        $type = uniqid('type_');
 
-        self::$client->revoke(self::$type, self::$client_2_id);
+        $record = self::$client->write($type, $data);
+
+        self::$client->share($type, self::$client_2_id);
+
+        $record2 = self::$client2->read($record->meta->record_id);
+
+        $this->assertEquals($record->data, $record2->data);
+
+        self::$client->revoke($type, self::$client_2_id);
 
         // If we've gotten to here with no errors or exceptions, then we assume sharing/revocation worked!
         $this->assertTrue(true);


### PR DESCRIPTION
Add a new `backup()` mechanism for client creation to back credentials up with the account service (and a console client registered to a specific account).

Fixes [E3DB-684](https://toznysecurity.atlassian.net/browse/E3DB-684)